### PR TITLE
Divide by zero avoidance in IHmethod's semilog interpolation

### DIFF
--- a/pydrograph/baseflow.py
+++ b/pydrograph/baseflow.py
@@ -203,8 +203,9 @@ def IHmethod(Qseries, block_length=5, tp=0.9, interp_semilog=True, freq='D', lim
     # interpolate between baseflow ordinates
     if interp_semilog:
         iszero = Q.ordinate.values == 0
-        logQ = np.log10(Q.ordinate)
+	logQ = Q.ordinate.copy()
         logQ[iszero] = -2
+        logQ = np.log10(Q.ordinate)
         QB = np.power(10.0, logQ.interpolate(limit=limit).values)
     else:
         QB = Q.ordinate.interpolate(limit=limit).values


### PR DESCRIPTION
It looks like the avoidance and log lines may have been out of order? Just thought I'd make this suggestion. (I'm still learning git, so this was a good opportunity to put it into action lol.)

No pressure, ofc!