### PR TITLE
IHmethod log-of-zero avoidance and log lines may have been out of order (V2)

### DIFF
--- a/pydrograph/baseflow.py
+++ b/pydrograph/baseflow.py
@@ -203,8 +203,9 @@ def IHmethod(Qseries, block_length=5, tp=0.9, interp_semilog=True, freq='D', lim
     # interpolate between baseflow ordinates
     if interp_semilog:
         iszero = Q.ordinate.values == 0
-        logQ = np.log10(Q.ordinate)
-        logQ[iszero] = -2
+	logQ = Q.ordinate.copy()
+        logQ[iszero] = 0.01
+        logQ = np.log10(logQ)
         QB = np.power(10.0, logQ.interpolate(limit=limit).values)
     else:
         QB = Q.ordinate.interpolate(limit=limit).values


### PR DESCRIPTION
It looks like the lines that turned 0s into 0.01s, and the line which actually took the log, might have been out of order? Just thought I'd make this suggestion. (I'm still learning git, so this was a good opportunity to put it into action lol. Earlier pull requests still had a line out of order -- my apologies about that.)

Thanks for your time, and no pressure, ofc!